### PR TITLE
Fix #162 and #163

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5379,8 +5379,10 @@ int mariadb_st_finish(SV* sth, imp_sth_t* imp_sth) {
   D_imp_xxh(sth);
   D_imp_dbh_from_sth;
 
-  if(imp_dbh->async_query_in_flight) {
-    mariadb_db_async_result(sth, &imp_sth->result);
+  if (imp_dbh->async_query_in_flight)
+  {
+    if (mariadb_db_async_result(sth, &imp_sth->result) == (my_ulonglong)-1)
+      return 0;
   }
 
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4802,6 +4802,7 @@ static int mariadb_st_describe(SV* sth, imp_sth_t* imp_sth)
       case MYSQL_TYPE_NULL:
         buffer->buffer_length= 0;
         buffer->buffer= NULL;
+        break;
 
       case MYSQL_TYPE_TINY:
         buffer->buffer_length= sizeof(fbh->numeric_val.tval);


### PR DESCRIPTION
Fixes:
* Add a missing break to 'MYSQL_TYPE_NULL' case in mariadb_st_describe()
* Signal error if mariadb_db_async_result() in mariadb_st_finish() fails
___

@jplesnik: Could you please review/verify that fixes in this pull request for your reported issues are OK?