### PR TITLE
Fix mariadb_use_result attribute

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -72,6 +72,7 @@ t/71impdata.t
 t/75supported_sql.t
 t/76multi_statement.t
 t/77max_allowed_packet.t
+t/78use_result.t
 t/80procs.t
 t/81procs.t
 t/85init_command.t

--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -181,6 +181,8 @@ mariadb_async_result(dbh)
             XSRETURN_PV("0E0");
         else if (retval == (my_ulonglong)-1)
             XSRETURN_UNDEF;
+        else if (retval == (my_ulonglong)-2)
+            XSRETURN_IV(-1);
 
         RETVAL = my_ulonglong2sv(retval);
     }
@@ -274,6 +276,9 @@ mariadb_async_result(sth)
 
         if (retval == (my_ulonglong)-1)
             XSRETURN_UNDEF;
+
+        if (retval == (my_ulonglong)-2)
+            XSRETURN_IV(-1);
 
         if (retval == 0)
             XSRETURN_PV("0E0");

--- a/MariaDB.xs
+++ b/MariaDB.xs
@@ -236,7 +236,7 @@ rows(sth)
             XSRETURN_UNDEF;
         }
     }
-    if (imp_sth->row_num == (my_ulonglong)-1)
+    if (imp_sth->row_num == (my_ulonglong)-1 || imp_sth->row_num == (my_ulonglong)-2)
         XSRETURN_IV(-1);
     RETVAL = my_ulonglong2sv(imp_sth->row_num);
   OUTPUT:

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4000,6 +4000,10 @@ static bool mariadb_st_free_result_sets(SV *sth, imp_sth_t *imp_sth, bool free_l
   if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)
     PerlIO_printf(DBIc_LOGPIO(imp_xxh), "\t>- mariadb_st_free_result_sets\n");
 
+  /* Iterate over all remaining rows, required when mysql_use_result() was called */
+  if (imp_sth->result)
+    while (mysql_fetch_row(imp_sth->result));
+
   do
   {
     if (DBIc_TRACE_LEVEL(imp_xxh) >= 2)

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4208,7 +4208,7 @@ bool mariadb_st_more_results(SV* sth, imp_sth_t* imp_sth)
     else
     {
       /* We have a new rowset */
-      imp_sth->row_num = mysql_num_rows(imp_sth->result);
+      imp_sth->row_num = use_mysql_use_result ? (my_ulonglong)-2 : mysql_num_rows(imp_sth->result);
 
       /* Adjust NUM_OF_FIELDS - which also adjusts the row buffer size */
       DBIc_DBISTATE(imp_sth)->set_attr_k(sth, sv_2mortal(newSVpvs("NUM_OF_FIELDS")), 0,
@@ -4354,6 +4354,8 @@ static my_ulonglong mariadb_st_internal_execute(
 
           if (mysql_errno(*svsock))
             rows = -1;
+          else if (use_mysql_use_result)
+            rows = (my_ulonglong)-2;
           else if (*result)
             rows = mysql_num_rows(*result);
           else {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5263,6 +5263,8 @@ process:
         mariadb_dr_do_error(sth, mysql_errno(imp_dbh->pmysql),
                  mysql_error(imp_dbh->pmysql),
                  mysql_sqlstate(imp_dbh->pmysql));
+      else if (imp_sth->row_num == (my_ulonglong)-2)
+        imp_sth->row_num = mysql_num_rows(imp_sth->result);
       if (!mysql_more_results(imp_dbh->pmysql))
         DBIc_ACTIVE_off(imp_sth);
       return Nullav;

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -626,6 +626,7 @@ struct imp_sth_st {
                           /* mysql_store_result */
 
     bool is_async;
+    bool async_result;
 };
 
 

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -1325,6 +1325,24 @@ Here's an example of how to use the asynchronous query interface:
   }
   my $rows = $dbh->mariadb_async_result();
 
+And another example:
+
+  my $fd = $dbh->mariadb_sockfd();
+
+  my $sth = $dbh->prepare('SELECT 1, SLEEP(10), t.id FROM t', { mariadb_async => 1 });
+  $sth->execute();
+
+  my $bits = '';
+  vec($bits, $fd, 1) = 1;
+  select($bits, undef, $bits, undef);
+
+  my $num_rows = $sth->mariadb_async_result();
+  print "num rows: $num_rows\n";
+  while (my @array = $sth->fetchrow_array()) {
+      print "row:\n";
+      print "\tvalue: $_\n" foreach @array;
+  }
+
 =head1 INSTALLATION
 
 See L<DBD::MariaDB::INSTALL>.

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -689,7 +689,10 @@ Note that library function C<mysql_use_result()> does not provide number of rows
 in result set. Therefore if this I<mariadb_use_result> attribute is enabled then
 DBI variable L<C<$DBI::rows>|DBI/$DBI::rows> and statement methods
 L<execute|DBI/execute> and L<rows|DBI/rows> returns C<-1> (which means that the
-number of rows is not known).
+number of rows is not known). However, statement method L<rows|DBI/rows> returns
+correct number of rows after all rows were already fetched and additional fetch
+call was issued (for this special case driver knows that it processed all rows
+and hence it knows what is the total number of rows).
 
 Enabling I<mariadb_use_result> attribute on one statement handle disallow usage
 of all other statement and database handles until all data rows from active

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -681,6 +681,25 @@ You can also set or unset the I<mariadb_use_result> setting on your statement
 handle, when creating the statement handle or after it has been created. See
 L</STATEMENT HANDLES>.
 
+Library functions C<mysql_use_result()> and C<mysql_store_result()> are not
+used for server side prepared statements, therefore this I<mariadb_use_result>
+attribute has no effect when server side prepared statements are enabled.
+
+Note that library function C<mysql_use_result()> does not provide number of rows
+in result set. Therefore if this I<mariadb_use_result> attribute is enabled then
+DBI variable L<C<$DBI::rows>|DBI/$DBI::rows> and statement methods
+L<execute|DBI/execute> and L<rows|DBI/rows> returns C<-1> (which means that the
+number of rows is not known).
+
+Enabling I<mariadb_use_result> attribute on one statement handle disallow usage
+of all other statement and database handles until all data rows from active
+statement handle are fetched. Trying to use other statement or database handles
+when there is active I<mariadb_use_result> attribute on some statement handle
+cause unpredictable errors.
+
+In most cases there is no benefit in usage of this I<mariadb_use_result>
+attribute, it should stay disabled.
+
 =item mariadb_bind_type_guessing
 
 This attribute causes the driver (emulated prepare statements) to attempt to

--- a/t/78use_result.t
+++ b/t/78use_result.t
@@ -1,0 +1,111 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Deep;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require 'lib.pl';
+
+my $dbh1 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0 });
+
+plan tests => 12 + 2*2*2*1 + 3 * (2*2*2*12 + 2*2*2 + 2*2*8);
+
+$SIG{__WARN__} = sub { die @_ };
+
+note "Testing use_result attribute";
+
+ok(!$dbh1->{mariadb_use_result});
+
+my $sth1 = $dbh1->prepare('SELECT 1', { mariadb_use_result => 1 });
+ok($sth1->{mariadb_use_result});
+ok(!$dbh1->{mariadb_use_result});
+ok($sth1->execute());
+ok($sth1->{mariadb_use_result});
+ok(!$dbh1->{mariadb_use_result});
+
+my $dbh2 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0, mariadb_use_result => 1 });
+ok($dbh2->{mariadb_use_result});
+
+my $sth2 = $dbh2->prepare('SELECT 1');
+ok($sth2->{mariadb_use_result});
+ok($dbh2->{mariadb_use_result});
+ok($sth2->execute());
+ok($sth2->{mariadb_use_result});
+ok($dbh2->{mariadb_use_result});
+
+for my $multi_statements (0, 1) {
+
+  my $dbh = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0, mariadb_multi_statements => $multi_statements });
+
+  $dbh->do('CREATE TEMPORARY TABLE t(a INT, b INT)');
+  $dbh->do('INSERT INTO t VALUES(0, 10)');
+  $dbh->do('INSERT INTO t VALUES(1, 20)');
+  $dbh->do('INSERT INTO t VALUES(2, 30)');
+
+  for my $async (0, 1) {
+
+    for my $use_result (0, 1) {
+
+      note "Testing with multi_statements=$multi_statements and async=$async and use_result=$use_result ...";
+
+      my $sth = $dbh->prepare($multi_statements ? 'SELECT * FROM t; SELECT * FROM t LIMIT 2 OFFSET 1;' : 'SELECT * FROM t', { mariadb_async => $async });
+      $sth->{mariadb_use_result} = $use_result;
+
+      is($sth->rows(), -1);
+
+      for (1..3) {
+
+        if ($async) {
+          is($sth->execute(), '0E0');
+          for (1..30) {
+            last if $sth->mariadb_async_ready();
+            sleep 1;
+          }
+          ok($sth->mariadb_async_ready());
+          cmp_deeply([ $sth->mariadb_async_result() ], [ any(-1, 3) ]);
+        } else {
+          cmp_deeply([ $sth->execute() ], [ any(-1, 3) ]);
+        }
+
+        cmp_deeply([ $sth->rows() ], [ any(-1, 3) ]);
+
+        ok($sth->{Active});
+        cmp_deeply($sth->fetchrow_arrayref(), [ 0, 10 ]);
+
+        ok($sth->{Active});
+        cmp_deeply($sth->fetchrow_arrayref(), [ 1, 20 ]);
+
+        ok($sth->{Active});
+        cmp_deeply($sth->fetchrow_arrayref(), [ 2, 30 ]);
+
+        ok(!$sth->fetchrow_arrayref());
+
+        if ($multi_statements) {
+          ok($sth->{Active});
+
+          ok($sth->more_results());
+          cmp_deeply([ $sth->rows() ], [ any(-1, 2) ]);
+
+          ok($sth->{Active});
+          cmp_deeply($sth->fetchrow_arrayref(), [ 1, 20 ]);
+
+          ok($sth->{Active});
+          cmp_deeply($sth->fetchrow_arrayref(), [ 2, 30 ]);
+
+          ok(!$sth->fetchrow_arrayref());
+        }
+
+        ok(!$sth->{Active});
+        ok(!$sth->more_results());
+        ok(!$sth->{Active});
+
+      }
+
+    }
+
+  }
+
+}

--- a/t/78use_result.t
+++ b/t/78use_result.t
@@ -11,7 +11,7 @@ require 'lib.pl';
 
 my $dbh1 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0 });
 
-plan tests => 12 + 2*2*2*1 + 3 * (2*2*2*12 + 2*2*2 + 2*2*8);
+plan tests => 12 + 2*2*2*1 + 3 * (2*2*2*13 + 2*2*2 + 2*2*9);
 
 $SIG{__WARN__} = sub { die @_ };
 
@@ -83,6 +83,8 @@ for my $multi_statements (0, 1) {
 
         ok(!$sth->fetchrow_arrayref());
 
+        is($sth->rows(), 3);
+
         if ($multi_statements) {
           ok($sth->{Active});
 
@@ -96,6 +98,8 @@ for my $multi_statements (0, 1) {
           cmp_deeply($sth->fetchrow_arrayref(), [ 2, 30 ]);
 
           ok(!$sth->fetchrow_arrayref());
+
+          is($sth->rows(), 2);
         }
 
         ok(!$sth->{Active});


### PR DESCRIPTION
Problems with mariadb_use_result attribute were reported in issue https://github.com/perl5-dbi/DBD-MariaDB/issues/173

This pull request fixes mariadb_use_result attribute also when it is used together with mariadb_multi_statements=1 or mariadb_async=1 option.

Fixes: https://github.com/perl5-dbi/DBD-MariaDB/issues/173