### PR TITLE
Croaks when changing AutoCommit attribute fails

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,7 @@ t/14destruct.t
 t/15reconnect.t
 t/16dbi-get_info.t
 t/17close_on_exec.t
+t/18begin_work_without_raise_error.t
 t/20createdrop.t
 t/25lockunlock.t
 t/29warnings.t

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2386,6 +2386,18 @@ static bool mariadb_dr_connect(
       imp_dbh->sock_fd = sock_os;
 #endif
 
+#ifdef _WIN32
+      {
+        /*
+         * Winsock SO_UPDATE_CONNECT_CONTEXT option needs to be set on the socket,
+         * otherwise getpeername, getsockname, getsockopt, setsockopt, and shutdown
+         * functions would fail with WSAENOTCONN error.
+         */
+        DWORD value = 1;
+        setsockopt(imp_dbh->sock_fd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, (const char *)&value, sizeof(value));
+      }
+#endif
+
       /*
         MySQL and MariaDB clients do not set FD_CLOEXEC flag on socket
         https://bugs.mysql.com/bug.php?id=3779

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -21,10 +21,14 @@
 /*
  * On WIN32 windows.h and winsock.h need to be included before mysql.h
  * Otherwise SOCKET type which is needed for mysql.h is not defined
+ * SO_UPDATE_CONNECT_CONTEXT is not defined in all MinGW versions.
  */
 #ifdef _WIN32
 #include <windows.h>
 #include <winsock.h>
+#ifndef SO_UPDATE_CONNECT_CONTEXT
+#define SO_UPDATE_CONNECT_CONTEXT 0x7010
+#endif
 #endif
 
 #include <mysql.h>  /* Comes with MySQL-devel */

--- a/t/15reconnect.t
+++ b/t/15reconnect.t
@@ -16,7 +16,7 @@ $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
   { RaiseError => 1, PrintError => 0 });
 $dbh->disconnect();
 
-plan tests => 18 * 2;
+plan tests => 21 * 2;
 
 for my $mariadb_server_prepare (0, 1) {
 $dbh= DBI->connect("$test_dsn;mariadb_server_prepare=$mariadb_server_prepare;mariadb_server_prepare_disable_fallback=1", $test_user, $test_password,
@@ -35,6 +35,12 @@ ok($dbh->disconnect(), "disconnecting active handle");
 ok(!$dbh->{Active}, "checking for inactive handle");
 
 ok($dbh->do("SELECT 1"), "implicitly reconnecting handle with 'do'");
+
+ok($dbh->{Active}, "checking for reactivated handle");
+
+ok(shutdown_mariadb_socket($dbh), "shutdown socket handle");
+
+ok($dbh->do("SELECT 1"), "implicitly reconnecting handle after shutdown with 'do'");
 
 ok($dbh->{Active}, "checking for reactivated handle");
 

--- a/t/18begin_work_without_raise_error.t
+++ b/t/18begin_work_without_raise_error.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require 'lib.pl';
+
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 0, PrintError => 1 });
+
+plan tests => 12;
+
+my $warn;
+$SIG{__WARN__} = sub { $warn = $_[0]; note "Caught DBI warn: $warn"; };
+
+my $error;
+$SIG{__DIE__} = sub { $error = $_[0]; note "Caught DBI error: $error"; };
+
+# Simulate network failure for this test by calling shutdown() on the MariaDB socket
+# This check that begin_work throw error on failure also when RaiseError is turned off
+ok(shutdown_mariadb_socket($dbh), "shutdown socket handle");
+
+ok(!$dbh->{RaiseError}, "RaiseError is not set");
+
+$error = undef;
+ok(!eval { $dbh->begin_work() }, "begin_work failed");
+like($error, qr/Changing AutoCommit attribute failed/, "begin_work croaked");
+ok($dbh->err(), "err is set");
+ok(length($dbh->errstr()), "errstr is set");
+
+ok(!$dbh->do('SELECT 1'), "do failed");
+ok($dbh->err(), "err is set");
+ok(length($dbh->errstr()), "errstr is set");
+
+$warn = undef;
+ok(!$dbh->commit(), "commit failed");
+like($warn, qr/commit ineffective with AutoCommit enabled/, "commit threw warning");
+
+ok($dbh->disconnect(), "disconnect");


### PR DESCRIPTION
This is expected by DBI for correct error propagation of AutoCommit and begin_work().

See: https://github.com/perl5-dbi/dbi/issues/104