### PR TITLE
Various fixes for tests

### DIFF
--- a/t/25lockunlock.t
+++ b/t/25lockunlock.t
@@ -36,12 +36,10 @@ ok defined($sth), "Prepare of select";
 
 ok  $sth->execute , "Execute";
 
-my ($row, $errstr);
-$errstr= '';
-$row = $sth->fetchrow_arrayref;
-$errstr= $sth->errstr;
+my $row = $sth->fetchrow_arrayref;
+my $err = $sth->err;
 ok !defined($row), "Fetch should have failed";
-ok !defined($errstr), "Fetch should have failed";
+ok !defined($err), "Fetch should have failed";
 
 ok $dbh->do("UNLOCK TABLES"), "Unlock tables";
 

--- a/t/35limit.t
+++ b/t/35limit.t
@@ -38,9 +38,9 @@ ok($sth = $dbh->prepare("SELECT * FROM dbd_mysql_t35 LIMIT ?, ?"),
 
 ok($sth->execute(20, 50), 'testing exec of bind vars for limit');
 
-my ($row, $errstr, $array_ref);
+my ($array_ref);
 ok( (defined($array_ref = $sth->fetchall_arrayref) &&
-  (!defined($errstr = $sth->errstr) || $sth->errstr eq '')));
+  (!$sth->err)));
 
 ok(@$array_ref == 50);
 

--- a/t/35prepare.t
+++ b/t/35prepare.t
@@ -7,7 +7,7 @@ use lib 't', '.';
 require 'lib.pl';
 
 my ($row, $sth, $dbh);
-my ($def, $rows, $errstr, $ret_ref);
+my ($def, $rows, $ret_ref);
 use vars qw($test_dsn $test_user $test_password);
 
 $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
@@ -30,7 +30,7 @@ ok($sth = $dbh->prepare("SHOW TABLES LIKE 'dbd_mysql_t35prepare'"),
 ok($sth->execute(), "Executing 'show tables'");
 
 ok((defined($row= $sth->fetchrow_arrayref) &&
-  (!defined($errstr = $sth->errstr) || $sth->errstr eq '')),
+  (!$sth->err)),
   "Testing if result set and no errors");
 
 ok($row->[0] eq 'dbd_mysql_t35prepare', "Checking if results equal to 'dbd_mysql_t35prepare' \n");

--- a/t/40listfields.t
+++ b/t/40listfields.t
@@ -15,7 +15,7 @@ my $create;
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 25;
+plan tests => 27;
 
 $dbh->{mariadb_server_prepare}= 0;
 
@@ -73,13 +73,8 @@ cmp_ok $ref->[0], 'eq', DBI::SQL_INTEGER(), "SQL_INTEGER";
 
 cmp_ok $ref->[1], 'eq', DBI::SQL_VARCHAR(), "SQL_VARCHAR";
 
-$sth = $dbh->prepare("SELECT * FROM dbd_mysql_40listfields");
-if (!$sth) {
-    die "Error:" . $dbh->errstr . "\n";
-}
-if (!$sth->execute) {
-    die "Error:" . $sth->errstr . "\n";
-}
+ok($sth = $dbh->prepare("SELECT * FROM dbd_mysql_40listfields"));
+ok($sth->execute);
 
 ok ($sth= $dbh->prepare("DROP TEMPORARY TABLE dbd_mysql_40listfields"));
 

--- a/t/40nulls_prepare.t
+++ b/t/40nulls_prepare.t
@@ -6,11 +6,9 @@ use DBI;
 use lib 't', '.';
 require 'lib.pl';
 
-my ($row, $sth, $dbh);
-my ($table, $def, $rows, $errstr, $ret_ref);
-use vars qw($table $test_dsn $test_user $test_password);
+use vars qw($test_dsn $test_user $test_password);
 
-$dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
+my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
     { RaiseError => 1, PrintError => 0 });
 
 ok(defined $dbh, "Connected to database");

--- a/t/40server_prepare_error.t
+++ b/t/40server_prepare_error.t
@@ -18,8 +18,7 @@ plan tests => 3;
 my $q = "select select select";	# invalid SQL
 my $sth;
 eval {$sth = $dbh->prepare($q);};
-ok defined($DBI::errstr);
-cmp_ok $DBI::errstr, 'ne', '';
+ok $dbh->err;
+ok $dbh->errstr and note 'errstr: ' . $dbh->errstr;
 
-note "errstr $DBI::errstr\n" if $DBI::errstr;
 ok $dbh->disconnect();

--- a/t/41bindparam.t
+++ b/t/41bindparam.t
@@ -13,7 +13,6 @@ $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0 });
 plan tests => 10;
 
-my ($rows, $errstr, $ret_ref);
 ok $dbh->do("drop table if exists dbd_mysql_41bindparam"), "drop table dbd_mysql_41bindparam";
 
 ok $dbh->do("create table dbd_mysql_41bindparam (a int not null, primary key (a))"), "create table dbd_mysql_41bindparam";

--- a/t/50commit.t
+++ b/t/50commit.t
@@ -41,7 +41,7 @@ my $engines = $dbh->selectall_hashref('SHOW ENGINES', 'Engine');
 my $have_innodb = exists $engines->{InnoDB} && $engines->{InnoDB}->{Support} ne 'NO';
 my $have_myisam = exists $engines->{MyISAM} && $engines->{MyISAM}->{Support} ne 'NO';
 
-plan tests => 1 + ($have_myisam ? 12 : 0) + ($have_innodb ? 22 : 0);
+plan tests => 1 + ($have_myisam ? 12 : 0) + ($have_innodb ? 21 : 0);
 
 if ($have_innodb) {
 
@@ -59,7 +59,6 @@ EOT
 
   $dbh->{AutoCommit} = 0;
   ok !$dbh->err;
-  ok !$dbh->errstr;
   ok !$dbh->{AutoCommit};
 
   ok $dbh->do("INSERT INTO dbd_mysql_t50commit VALUES (1, 'Jochen')"),

--- a/t/55utf8.t
+++ b/t/55utf8.t
@@ -67,7 +67,7 @@ EOI
 # Do not use prepared statements because ST_GeomFromText() is not supported
 # With SET SQL_MODE='' is mariadb_server_prepare_disable_fallback not working
 # And without SET SQL_MODE='' below 'Incorrect string value' are fatal errors, not warnings...
-my $sth = $dbh->prepare($query, { mariadb_server_prepare => 0 }) or die "$DBI::errstr";
+my $sth = $dbh->prepare($query, { mariadb_server_prepare => 0 });
 ok $sth->bind_param(1, $unicode_str);
 ok $sth->bind_param(2, $blob, DBI::SQL_BINARY);
 ok $sth->bind_param(3, $unicode_str);
@@ -75,7 +75,7 @@ ok $sth->bind_param(4, $unicode_str);
 ok $sth->bind_param(5, $unicode_str2);
 ok $sth->bind_param(6, $unicode_str);
 ok $sth->bind_param(7, $unicode_str2);
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 
 cmp_ok($dbh->{mariadb_warning_count}, '==', 1, 'got warning for INSERT') or do { diag("SHOW WARNINGS:"); diag($_->[2]) foreach $dbh->selectall_array("SHOW WARNINGS", { mariadb_server_prepare => 0 }); };
 my (undef, undef, $warning) = $dbh->selectrow_array("SHOW WARNINGS", { mariadb_server_prepare => 0 });
@@ -85,7 +85,7 @@ like($warning, qr/^(?:Incorrect string value: '\\xC4\\x80dam'|Data truncated) fo
 my $asbinary = $dbh->{mariadb_serverversion} >= 50706 ? 'ST_AsBinary' : 'AsBinary';
 
 $query = "SELECT name,bincol,$asbinary(shape), binutf, profile, str2, ascii, latin FROM dbd_mysql_t55utf8 LIMIT 1";
-$sth = $dbh->prepare($query) or die "$DBI::errstr";
+$sth = $dbh->prepare($query);
 
 ok $sth->execute;
 

--- a/t/55utf8_jp.t
+++ b/t/55utf8_jp.t
@@ -102,7 +102,7 @@ eval {
   $failed = 1;
 };
 $dbh->{PrintError} = 0;
-$SIG{__WARN__} = 'default';
+$SIG{__WARN__} = 'DEFAULT';
 
 ok($failed);
 like($DBI::errstr, $jpnErr);

--- a/t/55utf8mb4.t
+++ b/t/55utf8mb4.t
@@ -20,7 +20,7 @@ my $sth = $dbh->prepare("INSERT INTO dbd_mysql_t55utf8mb4(val) VALUES('😈')");
 $sth->execute();
 
 my $query = "SELECT val, HEX(val) FROM dbd_mysql_t55utf8mb4 LIMIT 1";
-$sth = $dbh->prepare($query) or die "$DBI::errstr";
+$sth = $dbh->prepare($query);
 ok $sth->execute;
 
 ok(my $ref = $sth->fetchrow_arrayref, 'fetch row');

--- a/t/65segfault.t
+++ b/t/65segfault.t
@@ -28,7 +28,7 @@ ok(defined $dbh, "Handle 1 Connected to database");
 ok(defined $dbh2, "Handle 2 Connected to database");
 
 #kill first db connection to trigger an auto reconnect
-ok ($dbh2->do('kill ' . $dbh->{'mariadb_thread_id'}));
+ok ($dbh2->do('kill ' . connection_id($dbh)));
 
 #insert a temporary delay, try uncommenting this if it's not seg-faulting at first,
 # one of my initial tests without this delay didn't seg fault

--- a/t/87async.t
+++ b/t/87async.t
@@ -152,10 +152,10 @@ cmp_ok(($end - $start), '>=', 1.9);
 $rows = $dbh->do('INSERT INTO async_test VALUES(SLEEP(2), ?, ?', { mariadb_async => 1 }, 1, 2);
 
 ok $rows;
-ok !$dbh->errstr;
+ok !$dbh->err;
 $rows = $dbh->mariadb_async_result;
 ok !$rows;
-ok $dbh->errstr;
+ok $dbh->err;
 
 $dbh->do('DELETE FROM async_test');
 

--- a/t/88async-multi-stmts.t
+++ b/t/88async-multi-stmts.t
@@ -36,14 +36,14 @@ ok !$sth1->{Active};
 ok !$sth2->{Active};
 
 ok !defined($sth1->mariadb_async_ready);
-ok $sth1->errstr;
+ok $sth1->err;
 ok !defined($sth1->mariadb_async_result);
-ok $sth1->errstr;
+ok $sth1->err;
 
 ok defined($sth0->mariadb_async_ready);
-ok !$sth1->errstr;
+ok !$sth1->err;
 ok defined($sth0->mariadb_async_result);
-ok !$sth1->errstr;
+ok !$sth1->err;
 
 ok !$sth0->{Active};
 ok !$sth1->{Active};

--- a/t/89async-method-check.t
+++ b/t/89async-method-check.t
@@ -101,7 +101,7 @@ foreach my $method (@db_safe_methods) {
     $dbh->do('SELECT 1', { mariadb_async => 1 });
     my $args = $dbh_args{$method} || [];
     $dbh->$method(@$args);
-    ok !$dbh->errstr, "Testing method '$method' on DBD::MariaDB::db during asynchronous operation";
+    ok !$dbh->err, "Testing method '$method' on DBD::MariaDB::db during asynchronous operation";
 
     ok defined($dbh->mariadb_async_result);
 }
@@ -123,7 +123,7 @@ foreach my $method (@common_safe_methods) {
     $sth->execute;
     my $args = $dbh_args{$method} || []; # they're common methods, so this should be ok!
     $sth->$method(@$args);
-    ok !$sth->errstr, "Testing method '$method' on DBD::MariaDB::db during asynchronous operation";
+    ok !$sth->err, "Testing method '$method' on DBD::MariaDB::db during asynchronous operation";
     ok defined($sth->mariadb_async_result);
     ok defined($sth->mariadb_async_result);
 }
@@ -133,7 +133,7 @@ foreach my $method (@st_safe_methods) {
     $sth->execute;
     my $args = $sth_args{$method} || [];
     $sth->$method(@$args);
-    ok !$sth->errstr, "Testing method '$method' on DBD::MariaDB::st during asynchronous operation";
+    ok !$sth->err, "Testing method '$method' on DBD::MariaDB::st during asynchronous operation";
 
     # statement safe methods cache async result and mariadb_async_result can be called multiple times
     ok defined($sth->mariadb_async_result), "Testing DBD::MariaDB::st method '$method' for async result";
@@ -145,9 +145,9 @@ foreach my $method (@st_safe_methods) {
     my $async_sth = $dbh->prepare('SELECT 1', { mariadb_async => 1 });
     $dbh->do('SELECT 1', { mariadb_async => 1 });
     ok !$sync_sth->execute;
-    ok $sync_sth->errstr;
+    ok $sync_sth->err;
     ok !$async_sth->execute;
-    ok $async_sth->errstr;
+    ok $async_sth->err;
     $dbh->mariadb_async_result;
 }
 
@@ -155,7 +155,7 @@ foreach my $method (@db_unsafe_methods) {
     my $sth = $dbh->prepare('SELECT 1', { mariadb_async => 1 });
     $sth->execute;
     ok !$dbh->do('SELECT 1', { mariadb_async => 1 });
-    ok $dbh->errstr;
+    ok $dbh->err;
     $sth->mariadb_async_result;
 }
 

--- a/t/90utf8_params.t
+++ b/t/90utf8_params.t
@@ -51,7 +51,7 @@ foreach my $server_prepare (0, 1) {
                 payload VARCHAR(20),
                 id int(10)
             ) CHARACTER SET $charset
-        }) or die $dbh->errstr;
+        });
 
 
         my $nasty_unicode1_param = $nasty_unicode1;
@@ -146,7 +146,7 @@ foreach my $server_prepare (0, 1) {
                 payload BLOB,
                 id int(10)
             ) CHARACTER SET $charset
-        }) or die $dbh->errstr;
+        });
 
         my $nasty_bytes1_param = $nasty_bytes1;
         my $nasty_bytes2_param = $nasty_bytes2;

--- a/t/91errcheck.t
+++ b/t/91errcheck.t
@@ -11,9 +11,10 @@ require 'lib.pl';
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 0, PrintError => 0, AutoCommit => 0 });
 
-plan tests => 1;
+plan tests => 2;
 
 $dbh->do( 'this should die' );
+ok $DBI::err, 'error number should be set on bad call';
 ok $DBI::errstr, 'error string should be set on a bad call';
 
 $dbh->disconnect;

--- a/t/rt25389-bin-case.t
+++ b/t/rt25389-bin-case.t
@@ -29,7 +29,7 @@ for my $charset (qw(latin1 utf8)) {
         my $create =
 "CREATE TEMPORARY TABLE `$table` (name VARCHAR(8) CHARACTER SET $charset COLLATE ${charset}_bin $unique)";
 
-        $dbh->do($create) or die $DBI::errstr;
+        $dbh->do($create);
         for (@test) {
             $dbh->do("insert into `$table` values ('$_')");
         }

--- a/t/rt88006-bit-prepare.t
+++ b/t/rt88006-bit-prepare.t
@@ -48,40 +48,40 @@ ok $dbh->do("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (1, b'10'
 ok $sth = $dbh->prepare("INSERT INTO dbd_mysql_rt88006_bit_prep (id, flags) VALUES (?, ?)");
 ok $sth->bind_param(1, 4, DBI::SQL_INTEGER);
 ok $sth->bind_param(2, pack("B*", '1110000000000000011101100000000011111101'), DBI::SQL_BINARY);
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 
 ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 1");
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 ok (my $r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario");
 is ($r->{id}, 1, 'id test contents');
 is (unpack("B*", $r->{flags}), '0000000000000000000000000000000000000010', 'flags has contents');
 
 ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 3");
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with more then 32 bits");
 is ($r->{id}, 3, 'id test contents');
 is (unpack("B*", $r->{flags}), '1111011111101111101101111111101111111101', 'flags has contents');
 
 ok $sth = $dbh->prepare("SELECT id,flags FROM dbd_mysql_rt88006_bit_prep WHERE id = 4");
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with binary insert");
 is ($r->{id}, 4, 'id test contents');
 is (unpack("B*", $r->{flags}), '1110000000000000011101100000000011111101', 'flags has contents');
 
 ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =1");
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN()");
 is ($r->{id}, 1, 'id test contents');
 is ($r->{'BIN(flags)'}, '10', 'flags has contents');
 
 ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =3");
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN() and more then 32 bits");
 is ($r->{id}, 3, 'id test contents');
 is ($r->{'BIN(flags)'}, '1111011111101111101101111111101111111101', 'flags has contents');
 
 ok $sth = $dbh->prepare("SELECT id,BIN(flags) FROM dbd_mysql_rt88006_bit_prep WHERE ID =4");
-ok $sth->execute() or die("Execute failed: ".$DBI::errstr);
+ok $sth->execute();
 ok ($r = $sth->fetchrow_hashref(), "fetchrow_hashref for $scenario with BIN() and with binary insert");
 is ($r->{id}, 4, 'id test contents');
 is ($r->{'BIN(flags)'}, '1110000000000000011101100000000011111101', 'flags has contents');


### PR DESCRIPTION
* Use connection_id() test helper function in t/65segfault.t test
* Fix checking for errors in tests
* Remove useless call of die in tests where RaiseError is enabled
* Fix resetting warning handler to default in t/55utf8_jp.t test