### PR TITLE
Improvements for database handle and connection attributes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -253,9 +253,15 @@ jobs:
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
       - name: Checkout git commit ${{ github.sha }}
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
+      - name: Checkout git commit ${{ github.event.pull_request.head.sha }} (fixup for pull request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup cpan sources cache
         uses: actions/cache@v3
         with:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,9 +24,9 @@ push @mysql_headers, 'mysql.h';
 
 our $opt = { "help" => \&Usage, };
 
-my ($test_host, $test_port, $test_socket);
+my ($test_host, $test_port, $test_socket, $test_authplugin);
 {
-local ($::test_host, $::test_port, $::test_user, $::test_socket, $::test_password, $::test_db, $::test_mysql_config, $::test_cflags, $::test_libs);
+local ($::test_host, $::test_port, $::test_user, $::test_socket, $::test_authplugin, $::test_password, $::test_db, $::test_mysql_config, $::test_cflags, $::test_libs);
 eval { require "./t/MariaDB.mtest" } and do {
 $opt->{'testuser'} = $::test_user;
 $opt->{'testpassword'} = $::test_password;
@@ -37,6 +37,7 @@ $opt->{'libs'} = $::test_libs;
 $test_host = $::test_host;
 $test_port = $::test_port;
 $test_socket = $::test_socket;
+$test_authplugin = $::test_authplugin;
 }
 }
 
@@ -49,6 +50,7 @@ Getopt::Long::GetOptions(
     "testuser:s",
     "testpassword:s",
     "testsocket:s",
+    "testauthplugin:s",
     "cflags:s",
     "libs:s",
     "mysql_config:s",
@@ -104,7 +106,7 @@ MSG
     }
   }
 
-for my $key (qw(testdb testhost testuser testpassword testsocket testport cflags libs))
+for my $key (qw(testdb testhost testuser testpassword testsocket testauthplugin testport cflags libs))
 {
   Configure($opt, $source, $key);
 }
@@ -136,7 +138,7 @@ if ( $opt->{testport} && !$opt->{testhost} ) {
   $source->{testhost} = 'guessed';
 }
 
-foreach (qw(testhost testport testsocket)) {
+foreach (qw(testhost testport testsocket testauthplugin)) {
   next if defined $opt->{$_};
   $opt->{$_} = '';
   $source->{$_} = 'default';
@@ -419,12 +421,14 @@ my $fileName = File::Spec->catfile("t", "MariaDB.mtest");
 	      "\$::test_port = \$opt->{'testport'};\n" .
 	      "\$::test_user = \$opt->{'testuser'};\n" .
               "\$::test_socket = \$opt->{'testsocket'};\n" .
+              "\$::test_authplugin = \$opt->{'testauthplugin'};\n" .
 	      "\$::test_password = \$opt->{'testpassword'};\n" .
 	      "\$::test_db = \$opt->{'testdb'};\n" .
 	      "\$::test_dsn = \"DBI:MariaDB:\$::test_db\";\n" .
               "\$::test_dsn .= \":\$::test_host\" if \$::test_host;\n" .
 	      "\$::test_dsn .= \":\$::test_port\" if \$::test_port;\n".
 	      "\$::test_dsn .= \";mariadb_socket=\$::test_socket\" if \$::test_socket;\n" .
+	      "\$::test_dsn .= \";mariadb_auth_plugin=\$::test_authplugin\" if \$::test_authplugin;\n" .
 	      "\$::test_dsn .= \";mariadb_connect_timeout=120;mariadb_read_timeout=120;mariadb_write_timeout=120\";\n" .
 	      "\$::test_mysql_config = \$opt->{'mysql_config'} if \$source->{'mysql_config'} eq 'User\\'s choice';\n" .
 	      "\$::test_cflags = \$opt->{'cflags'} if \$source->{'cflags'} eq 'User\\'s choice';\n" .
@@ -654,6 +658,9 @@ Possible options are:
                          the database server; by default unix socket is chosen
                          by mariadb/mysqlclient library; takes effect only
                          when --testhost is set to "localhost"
+  --testauthplugin=<ap>  Use <ap> auth plugin when doing user authentication
+                         handshake with server; for older server versions it is
+                         needed to pass "mysql_native_password"
   --mariadb_config       Synonym for --mysql_config, override it
   --mysql_config=<path>  Specify <path> for mariadb_config or mysql_config script
   --help                 Print this message and exit
@@ -885,7 +892,7 @@ section "Linker flags" or type
   perl Makefile.PL --help
 MSG
     }
-    elsif ($param eq "testhost" || $param eq "testport" || $param eq "testsocket") {
+    elsif ($param eq "testhost" || $param eq "testport" || $param eq "testsocket" || $param eq "testauthplugin") {
       # known parameter, but do nothing
     }
     else {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1994,13 +1994,10 @@ static bool mariadb_dr_connect(
         }
 
         (void)hv_stores(processed, "mariadb_multi_statements", &PL_sv_yes);
-	if ((svp = hv_fetchs(hv, "mariadb_multi_statements", FALSE)) && *svp)
+        if ((svp = hv_fetchs(hv, "mariadb_multi_statements", FALSE)) && *svp && SvTRUE(*svp))
         {
-	  if (SvTRUE(*svp))
-	    client_flag |= CLIENT_MULTI_STATEMENTS;
-          else
-            client_flag &= ~CLIENT_MULTI_STATEMENTS;
-	}
+          client_flag |= CLIENT_MULTI_STATEMENTS;
+        }
 
         (void)hv_stores(processed, "mariadb_server_prepare", &PL_sv_yes);
 	if ((svp = hv_fetchs(hv, "mariadb_server_prepare", FALSE)) && *svp)

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1924,13 +1924,8 @@ static bool mariadb_dr_connect(
         }
 
         (void)hv_stores(processed, "mariadb_client_found_rows", &PL_sv_yes);
-        if ((svp = hv_fetchs(hv, "mariadb_client_found_rows", FALSE)) && *svp)
-        {
-          if (SvTRUE(*svp))
-            client_flag |= CLIENT_FOUND_ROWS;
-          else
-            client_flag &= ~CLIENT_FOUND_ROWS;
-        }
+        if ((svp = hv_fetchs(hv, "mariadb_client_found_rows", FALSE)) && *svp && !SvTRUE(*svp))
+          client_flag &= ~CLIENT_FOUND_ROWS;
 
         (void)hv_stores(processed, "mariadb_auto_reconnect", &PL_sv_yes);
         if ((svp = hv_fetchs(hv, "mariadb_auto_reconnect", FALSE)) && *svp)

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -537,6 +537,7 @@ struct imp_dbh_st {
                                */
     bool use_server_side_prepare;
     bool disable_fallback_for_server_prepare;
+    bool use_multi_statements;
     void* async_query_in_flight;
     my_ulonglong insertid;
     struct {

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -248,6 +248,19 @@ server. This is done, for example, with
 Usually there's no need for this option, unless you are using another location
 for the socket than that built into the client.
 
+=item mariadb_auth_plugin
+
+Specify authentication method used during connection to MariaDB or MySQL server.
+MySQL protocol uses C<mysql_native_password> authentication method and MySQL
+version 5.5.7 extended protocol and added support for using other authentication
+methods which can be provided to clients by plugins. MySQL version 8.0.4 changed
+the default authentication method to C<caching_sha2_password>.
+
+Example how to use C<caching_sha2_password> authentication method:
+
+  my $dsn = 'DBI:MariaDB:database=test;host=hostname;'
+          . 'mariadb_auth_plugin=caching_sha2_password';
+
 =item mariadb_ssl
 
 A true value enforces SSL encryption when connecting to the MariaDB or MySQL

--- a/lib/DBD/MariaDB.pod
+++ b/lib/DBD/MariaDB.pod
@@ -133,6 +133,10 @@ This is similar to the behavior of the C<mariadb> or C<mysql> command line
 client. Also, C<SELECT DATABASE()> will return the current database active for
 the handle.
 
+The DBD::MariaDB driver understands any connection attribute specified in
+L</DATABASE HANDLES> section which is read/write and additionally also any
+other attribute described below.
+
 =over
 
 =item host
@@ -349,58 +353,6 @@ client library by default. If your DSN contains the option
 C<mariadb_local_infile=1>, C<LOAD DATA LOCAL> will be enabled. However, this
 option is B<ineffective> if the server has also been configured to disallow
 C<LOCAL>.
-
-=item mariadb_multi_statements
-
-Support for multiple statements separated by a semicolon (C<;>) may be enabled
-by using this option. Enabling this option may cause problems if server-side
-prepared statements are also enabled.
-
-=item mariadb_server_prepare
-
-This option is used to enable server side prepared statements. By default
-prepared statements are not used and placeholder replacement is done by
-DBD::MariaDB prior to sending SQL statement to MariaDB or MySQL server.
-
-This default behavior may change in the future.
-
-To use server side prepared statements, all you need to do is set the variable
-I<mariadb_server_prepare> in the connect:
-
-  my $dbh = DBI->connect(
-      'DBI:MariaDB:database=test;host=localhost;mariadb_server_prepare=1',
-      'user',
-      'password',
-      { RaiseError => 1, PrintError => 0 },
-  );
-
-or:
-
-  my $dbh = DBI->connect(
-      'DBI:MariaDB:database=test;host=localhost',
-      'user',
-      'password',
-      { RaiseError => 1, PrintError => 0, mariadb_server_prepare => 1 },
-  );
-
-There are many benefits to using server side prepare statements, mostly if you
-are using SQL statements with placeholders or performing many inserts because of
-that fact that a single statement is prepared to accept multiple insert values.
-
-Please note that MariaDB or MySQL server cannot prepare or execute some prepared
-statements. In this case DBD::MariaDB fallbacks to normal non-prepared statement
-and tries again.
-
-=item mariadb_server_prepare_disable_fallback
-
-This option disable fallback to normal non-prepared statement when MariaDB or
-MySQL server does not support execution of current statement as prepared.
-
-Useful when you want to be sure that the statement is going to be executed as
-server side prepared. Error message and code in case of failure is propagated
-back to DBI.
-
-This default behavior may change in the future.
 
 =item mariadb_embedded_options
 
@@ -795,6 +747,58 @@ intermediate string and any bind parameter. Default value depends on client
 MariaDB/MySQL library and should be 1GB.
 
   $dbh->{mariadb_max_allowed_packet} = 32*1024*1024; # limit max size to 32MB
+
+=item mariadb_multi_statements
+
+Support for multiple statements separated by a semicolon (C<;>) may be enabled
+by using this option. Enabling this option may cause problems if server-side
+prepared statements are also enabled.
+
+=item mariadb_server_prepare
+
+This option is used to enable server side prepared statements. By default
+prepared statements are not used and placeholder replacement is done by
+DBD::MariaDB prior to sending SQL statement to MariaDB or MySQL server.
+
+This default behavior may change in the future.
+
+To use server side prepared statements, all you need to do is set the variable
+I<mariadb_server_prepare> in the connect:
+
+  my $dbh = DBI->connect(
+      'DBI:MariaDB:database=test;host=localhost;mariadb_server_prepare=1',
+      'user',
+      'password',
+      { RaiseError => 1, PrintError => 0 },
+  );
+
+or:
+
+  my $dbh = DBI->connect(
+      'DBI:MariaDB:database=test;host=localhost',
+      'user',
+      'password',
+      { RaiseError => 1, PrintError => 0, mariadb_server_prepare => 1 },
+  );
+
+There are many benefits to using server side prepare statements, mostly if you
+are using SQL statements with placeholders or performing many inserts because of
+that fact that a single statement is prepared to accept multiple insert values.
+
+Please note that MariaDB or MySQL server cannot prepare or execute some prepared
+statements. In this case DBD::MariaDB fallbacks to normal non-prepared statement
+and tries again.
+
+=item mariadb_server_prepare_disable_fallback
+
+This option disable fallback to normal non-prepared statement when MariaDB or
+MySQL server does not support execution of current statement as prepared.
+
+Useful when you want to be sure that the statement is going to be executed as
+server side prepared. Error message and code in case of failure is propagated
+back to DBI.
+
+This default behavior may change in the future.
 
 =back
 

--- a/lib/DBD/MariaDB/INSTALL.pod
+++ b/lib/DBD/MariaDB/INSTALL.pod
@@ -147,6 +147,7 @@ them in your .bashrc or the like:
   export DBD_MARIADB_TESTHOST=127.0.0.1
   export DBD_MARIADB_TESTPORT=3306
   export DBD_MARIADB_TESTSOCKET=/var/run/mysqld/mysqld.sock
+  export DBD_MARIADB_TESTAUTHPLUGIN=mysql_native_password
   export DBD_MARIADB_TESTUSER=me
   export DBD_MARIADB_TESTPASSWORD=s3kr1+
 

--- a/t/76multi_statement.t
+++ b/t/76multi_statement.t
@@ -14,7 +14,7 @@ my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password,
                       { RaiseError => 1, PrintError => 0, AutoCommit => 0,
                         mariadb_multi_statements => 1 });
 
-plan tests => 77;
+plan tests => 81;
 
 ok (defined $dbh, "Connected to database with multi statement support");
 
@@ -124,5 +124,13 @@ $dbh->{mariadb_server_prepare}= 0;
   ok(!eval { $sth->{NAME} });
   ok(!eval { $sth->{mariadb_type} });
   is($sth->rows, -1);
+
+  # Check that it is possible to turn off/on mariadb_multi_statements at runtime
+  $dbh->{mariadb_multi_statements} = 0;
+  ok(!$dbh->{mariadb_multi_statements});
+  ok(!eval { $dbh->do("SELECT 1; SELECT 1;") });
+  $dbh->{mariadb_multi_statements} = 1;
+  ok($dbh->{mariadb_multi_statements});
+  ok($dbh->do("SELECT 1; SELECT 1;"));
 
 $dbh->disconnect();


### PR DESCRIPTION
* Allow to modify `$dbh->{mariadb_multi_statements}` also after connection to server was established
* Allow to specify `mariadb_auth_plugin` connection attribute