### PR TITLE
Fix support for MySQL 8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
             - 5.32.0
             - 5.34.0
             - 5.36.0
+            - 5.38.0
             - system
           dbi-version:
             - 1.627
@@ -50,6 +51,7 @@ jobs:
             - mysql-5.0.96
             - mysql-5.1.30
             - mysql-5.1.72
+            - mysql-5.1.73
             - mysql-5.5.8
             - mysql-5.5.47
             - mysql-5.5.49
@@ -71,6 +73,7 @@ jobs:
             - mysql-5.6.41
             - mysql-5.6.43
             - mysql-5.6.45
+            - mysql-5.6.51
             - mysql-5.7.8-rc
             - mysql-5.7.11
             - mysql-5.7.12
@@ -83,6 +86,7 @@ jobs:
             - mysql-5.7.23
             - mysql-5.7.25
             - mysql-5.7.27
+            - mysql-5.7.43
             - mysql-8.0.0-dmr
             - mysql-8.0.1-dmr
             - mysql-8.0.2-dmr
@@ -95,6 +99,11 @@ jobs:
             - mysql-8.0.15
             - mysql-8.0.16
             - mysql-8.0.17
+            - mysql-8.0.20
+            - mysql-8.0.21
+            - mysql-8.0.22
+            - mysql-8.0.33
+            - mysql-8.0.34
             - mariadb-5.5.40
             - mariadb-5.5.44
             - mariadb-5.5.47
@@ -109,6 +118,7 @@ jobs:
             - mariadb-5.5.61
             - mariadb-5.5.63
             - mariadb-5.5.65
+            - mariadb-5.5.68
             - mariadb-10.0.14
             - mariadb-10.0.20
             - mariadb-10.0.23
@@ -132,6 +142,7 @@ jobs:
             - mariadb-10.1.37
             - mariadb-10.1.38
             - mariadb-10.1.41
+            - mariadb-10.1.48
             - mariadb-10.2.0
             - mariadb-10.2.1
           # Incompatible, broken mysql_config
@@ -154,6 +165,7 @@ jobs:
             - mariadb-10.2.21
             - mariadb-10.2.22
             - mariadb-10.2.26
+            - mariadb-10.2.44
             - mariadb-10.3.0
             - mariadb-10.3.1
             - mariadb-10.3.2
@@ -166,6 +178,7 @@ jobs:
             - mariadb-10.3.11
             - mariadb-10.3.12
             - mariadb-10.3.17
+            - mariadb-10.3.39
             - mariadb-10.4.0
             - mariadb-10.4.1
             - mariadb-10.4.2
@@ -213,6 +226,12 @@ jobs:
             - mariadbconc-3.1.1
             - mariadbconc-3.1.2
             - mariadbconc-3.1.3
+            - mariadbconc-3.1.10
+            - mariadbconc-3.1.21
+            - mariadbconc-3.2.0
+            - mariadbconc-3.2.7
+            - mariadbconc-3.3.0-rc1
+            - mariadbconc-3.3.5
             - system
             - same-as-server
           include:
@@ -338,10 +357,11 @@ jobs:
               5.6.[12]*)        SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.5-x86_64.tar.gz ;;
               5.6.3[0123456]*)  SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.5-x86_64.tar.gz ;;
               5.6.*)            SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.gz ;;
-              5.7.19*|5.7.[2]*) SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.gz ;;
+              5.7.19*|5.7.[234]*) SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.gz ;;
               5.7.*)            SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.5-x86_64.tar.gz ;;
               8.0.?-*|8.0.11)   SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.gz ;;
               8.0.*)            SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.12-x86_64.tar.xz ;;
+              8.1.*)            SANDBOX_URL=https://dev.mysql.com/get/mysql-$VERSION-linux-glibc2.28-x86_64.tar.xz ;;
               *)                echo "Unsupported MySQL version '$VERSION'"; exit 1 ;;
             esac
             SANDBOX_CACHE_FILE="$HOME/cache/$(basename "$SANDBOX_URL")"
@@ -376,8 +396,13 @@ jobs:
             esac
             CONC_FILE="$HOME/cache/$(basename "$CONC_URL")"
           elif [ "$CONC_DB" = "MariaDB" ]; then
-            CONC_URL=https://downloads.mariadb.com/Connectors/c/connector-c-${CONC_VERSION/-*/}/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz
-            CONC_FILE="$HOME/cache/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz"
+            case "$CONC_VERSION" in
+              3.0.*)            CONC_URL=https://downloads.mariadb.com/Connectors/c/connector-c-${CONC_VERSION/-*/}/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz ;;
+              3.1.[01234567])   CONC_URL=https://downloads.mariadb.com/Connectors/c/connector-c-${CONC_VERSION/-*/}/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz ;;
+              3.*)              CONC_URL=https://downloads.mariadb.com/Connectors/c/connector-c-${CONC_VERSION/-*/}/mariadb-connector-c-$CONC_VERSION-ubuntu-focal-amd64.tar.gz ;;
+              *)                CONC_URL=https://downloads.mariadb.com/Connectors/c/connector-c-${CONC_VERSION/-*/}/mariadb-connector-c-$CONC_VERSION-linux-x86_64.tar.gz ;;
+            esac
+            CONC_FILE="$HOME/cache/$(basename "$CONC_URL")"
           elif [ -n "$CONC_DB" ]; then
             echo "Unsupported Connector/C '$CONC_DB'"; exit 1
           fi

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3098,6 +3098,7 @@ static void mariadb_dr_close_mysql(pTHX_ imp_drh_t *imp_drh, MYSQL *pmysql)
      * - infinite loop when calling mysql_server_end() more then once in case Embedded server was not started
      * Therefore do not call mysql_server_end() when Embedded server was not in used.
      * These bugs were fixed in MariaDB Connector/C 3.0.5, see: https://jira.mariadb.org/browse/CONC-336
+     * And fixed also in MySQL 8.0.20, see: https://bugs.mysql.com/bug.php?id=93276
      * But remains in MariaDB Embedded server, see: https://jira.mariadb.org/browse/MDEV-16578
      */
 #if !defined(HAVE_BROKEN_INIT) && (defined(HAVE_DEINITIALIZE_SSL) || !defined(HAVE_PROBLEM_WITH_OPENSSL))

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2362,10 +2362,13 @@ static bool mariadb_dr_connect(
         so that we can keep track of when this happens.
       */
 #if MYSQL_VERSION_ID >= 50013
+    /* Beginning with MySQL 8.0.34, the automatic reconnection feature is deprecated and disabled by default. */
+#if defined(MARIADB_BASE_VERSION) || MYSQL_VERSION_ID < 80034
     {
       my_bool reconnect = FALSE;
       mysql_options(sock, MYSQL_OPT_RECONNECT, &reconnect);
     }
+#endif
 #else
       sock->reconnect = FALSE;
 #endif

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -373,9 +373,9 @@ PERL_STATIC_INLINE unsigned long mariadb_get_client_version(void)
 /*
  * MySQL and MariaDB Embedded are affected by https://jira.mariadb.org/browse/MDEV-16578
  * MariaDB 10.2.2+ prior to 10.2.19 and 10.3.9 and MariaDB Connector/C prior to 3.0.5 are affected by https://jira.mariadb.org/browse/CONC-336
- * MySQL 8.0.4+ is affected too by https://bugs.mysql.com/bug.php?id=93276
+ * MySQL 8.0.4+ prior to 8.0.20 is affected too by https://bugs.mysql.com/bug.php?id=93276
  */
-#if defined(HAVE_EMBEDDED) || (!defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80004) || (defined(MARIADB_PACKAGE_VERSION) && (!defined(MARIADB_PACKAGE_VERSION_ID) || MARIADB_PACKAGE_VERSION_ID < 30005)) || (defined(MARIADB_BASE_VERSION) && ((MYSQL_VERSION_ID >= 100202 && MYSQL_VERSION_ID < 100219) || (MYSQL_VERSION_ID >= 100300 && MYSQL_VERSION_ID < 100309)))
+#if defined(HAVE_EMBEDDED) || (!defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80004 && MYSQL_VERSION_ID < 80020) || (defined(MARIADB_PACKAGE_VERSION) && (!defined(MARIADB_PACKAGE_VERSION_ID) || MARIADB_PACKAGE_VERSION_ID < 30005)) || (defined(MARIADB_BASE_VERSION) && ((MYSQL_VERSION_ID >= 100202 && MYSQL_VERSION_ID < 100219) || (MYSQL_VERSION_ID >= 100300 && MYSQL_VERSION_ID < 100309)))
 #define HAVE_BROKEN_INIT
 #endif
 

--- a/t/40server_prepare.t
+++ b/t/40server_prepare.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use DBI;
+use DBI::Const::GetInfoType;
 use lib 't', '.';
 require 'lib.pl';
 use vars qw($test_dsn $test_user $test_password $test_db);
@@ -73,7 +74,7 @@ ok($sth3->execute(1, 2), "insert t3");
 is_deeply($dbh->selectall_arrayref('SELECT id, mydata FROM t3'), [[1, 2]]);
 
 # MariaDB server since version 10.6.2 can prepare all statements except PREPARE, EXECUTE, and DEALLOCATE / DROP PREPARE. Previous MariaDB and MySQL versions cannot prepare USE statement.
-my $non_preparable_statement = ($dbh->{mariadb_serverversion} >= 100602) ? q(PREPARE stmt FROM "SELECT 1") : ("USE " . $dbh->quote_identifier($test_db));
+my $non_preparable_statement = ($dbh->get_info($GetInfoType{SQL_DBMS_NAME}) eq 'MariaDB' and $dbh->{mariadb_serverversion} >= 100602) ? q(PREPARE stmt FROM "SELECT 1") : ("USE " . $dbh->quote_identifier($test_db));
 
 $dbh->{mariadb_server_prepare_disable_fallback} = 1;
 my $error_handler_called = 0;

--- a/t/rt122541-decimals.t
+++ b/t/rt122541-decimals.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use DBI;
+use DBI::Const::GetInfoType;
 
 use vars qw($test_dsn $test_user $test_password);
 use lib 't', '.';
@@ -14,6 +15,9 @@ plan tests => 2;
 
 for my $mariadb_server_prepare (0, 1) {
 	$dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
+	SKIP: {
+	skip 'MySQL 8.0.22+ server have broken ROUND() function', 1 if $dbh->get_info($GetInfoType{SQL_DBMS_NAME}) eq 'MySQL' and $dbh->{mariadb_serverversion} >= 80022;
 	is $dbh->selectrow_arrayref('SELECT round(degrees(0.00043) * 69, 2)')->[0], '1.70',
 		'floats with fixed-length of decimals returns correct value for mariadb_server_prepare=' . $mariadb_server_prepare;
+	}
 }

--- a/t/rt122541-decimals.t
+++ b/t/rt122541-decimals.t
@@ -11,10 +11,16 @@ require "lib.pl";
 
 my $dbh = DbiTestConnect($test_dsn, $test_user, $test_password, { PrintError => 0, RaiseError => 1 });
 
-plan tests => 2;
+plan tests => 4;
 
 for my $mariadb_server_prepare (0, 1) {
 	$dbh->{mariadb_server_prepare} = $mariadb_server_prepare;
+	SKIP: {
+	skip "Servers < 5.0.8 do not support DECIMAL argument for CAST()", 1 if $dbh->{mariadb_serverversion} < 50008;
+	skip "Clients < 5.0.3 do not support new decimal type from servers >= 5.0.3", 1 if $dbh->{mariadb_serverversion} >= 50003 and $dbh->{mariadb_clientversion} < 50003;
+	is $dbh->selectrow_arrayref('SELECT CAST(DEGREES(0.00043) * 69 AS DECIMAL(65, 2))')->[0], '1.70',
+		'float casted to decimal with fixed length and trailing zeros returns correct value for mariadb_server_prepare=' . $mariadb_server_prepare;
+	}
 	SKIP: {
 	skip 'MySQL 8.0.22+ server have broken ROUND() function', 1 if $dbh->get_info($GetInfoType{SQL_DBMS_NAME}) eq 'MySQL' and $dbh->{mariadb_serverversion} >= 80022;
 	is $dbh->selectrow_arrayref('SELECT round(degrees(0.00043) * 69, 2)')->[0], '1.70',

--- a/t/rt85919-fetch-lost-connection.t
+++ b/t/rt85919-fetch-lost-connection.t
@@ -34,12 +34,18 @@ if (not $ok) {
     # if we're connected via a local socket we receive error 2006
     # (CR_SERVER_GONE_ERROR) but if we're connected using TCP/IP we get 
     # 2013 (CR_SERVER_LOST)
+    #
+    # as of 8.0.24 MySQL writes the reason the connection was closed
+    # before closing it, so 4031 (ER_CLIENT_INTERACTION_TIMEOUT) is
+    # now an valid return code
     if ($DBI::err == 2006) {
        pass("received error 2006 (CR_SERVER_GONE_ERROR)");
     } elsif ($DBI::err == 2013) {
        pass("received error 2013 (CR_SERVER_LOST)");
+    } elsif ($DBI::err == 4031) {
+       pass("received error 4031 (ER_CLIENT_INTERACTION_TIMEOUT)");
     } else {
-        fail('Should return error 2006 or 2013');
+        fail("Should return error 2006 or 2013 or 4031 but returned $DBI::err");
     }
     eval { $sth->finish(); } if defined $sth;
     eval { $dbh->disconnect(); } if defined $dbh;


### PR DESCRIPTION
* Add new versions for testing on Github Actions CI
* Do not use MYSQL_OPT_RECONNECT for MySQL 8.0.34+ clients
* MySQL 8.0.20 client library has fixed reinitialization bug
* Fix MariaDB server version check in t/40server_prepare.t test
* Skip t/rt122541-decimals.t test for MySQL 8.0.22+ server versions
* Add new DECIMAL testcase into t/rt122541-decimals.t
* accept 4031 as a valid return code when connection closed