### PR TITLE
Add a workaround for broken MariaDB clients which overwrite SIGPIPE handler

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -23,6 +23,7 @@ t/15reconnect.t
 t/16dbi-get_info.t
 t/17close_on_exec.t
 t/18begin_work_without_raise_error.t
+t/19sigpipe.t
 t/20createdrop.t
 t/25lockunlock.t
 t/29warnings.t

--- a/t/19sigpipe.t
+++ b/t/19sigpipe.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+
+use Test::More;
+use DBI;
+
+use vars qw($test_dsn $test_user $test_password);
+use lib 't', '.';
+require 'lib.pl';
+
+plan skip_all => '$SIG{PIPE} is not supported' unless exists $SIG{PIPE};
+
+plan tests => 1;
+
+my $sigpipe_handler_called;
+$SIG{PIPE} = sub { $sigpipe_handler_called = 1; };
+
+DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 0, PrintError => 0, AutoCommit => 0 });
+
+kill('PIPE', $$);
+
+ok($sigpipe_handler_called, 'DBI->connect() does not overwrite $SIG{PIPE} handler');


### PR DESCRIPTION
MariaDB Connector/C 3.0.0 in function mysql_server_init() for non-Windows systems started setting SIGPIPE handler to SIG_IGN. This breaks Perl applications which installed its own SIGPIPE signal handler.

As a workaround use Perl rsignal_save() function to save existing SIGPIPE handler before calling mysql_server_init() and after that restore saved handler via Perl rsignal_restore() function.

Add a test which verifies that DBI->connect() which calls DBD::MariaDB's mariadb_dr_connect() function and which calls mysql_server_init(), does not overwrite $SIG{PIPE} handler set in Perl code.

Fixes: https://github.com/perl5-dbi/DBD-MariaDB/issues/170
See: http://jira.mariadb.org/browse/CONC-591