### PR TITLE
Do not call mariadb_db_reconnect() during changing $dbh attributes unless needed

### DIFF
--- a/t/13disconnect.t
+++ b/t/13disconnect.t
@@ -10,11 +10,21 @@ require 'lib.pl';
 
 my $dbh1 = DbiTestConnect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0 });
 
-plan tests => 17;
+plan tests => 19;
 
+my $err1;
+my $err2;
+# set HandleError with catching of all errors
+$dbh1->{HandleError} = sub { $err1 = $_[0]; };
+{
+# localize HandleError with different closure and ensure that the original one is restored after the disconnect()
+local $dbh1->{HandleError} = sub { $err2 = $_[0]; };
 ok $dbh1->{Active};
 ok $dbh1->disconnect();
 ok !$dbh1->{Active};
+}
+ok !defined $err1 or diag $err1;
+ok !defined $err2 or diag $err2;
 
 ok my $dbh2 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0 });
 ok my $dbh3 = DBI->connect($test_dsn, $test_user, $test_password, { RaiseError => 1, PrintError => 0 });


### PR DESCRIPTION
Fixes #211.